### PR TITLE
fix: re-render should not register additonal hover listeners

### DIFF
--- a/packages/react-vega/src/Vega.jsx
+++ b/packages/react-vega/src/Vega.jsx
@@ -99,14 +99,12 @@ class Vega extends React.Component {
         });
       }
 
-      if (props.enableHover !== prevProps.enableHover) {
+      if (!prevProps.enableHover && props.enableHover) {
+        this.view.hover();
         changed = true;
       }
 
       if (changed) {
-        if (props.enableHover) {
-          this.view.hover();
-        }
         this.view.run();
       }
     }


### PR DESCRIPTION
fix #30

The performance of our interactive visualization tool was poor just because this little bug. Hope this help.