### PR TITLE
Update some demo attributes

### DIFF
--- a/packages/react-vega-demo/stories/ReactVegaDemo.jsx
+++ b/packages/react-vega-demo/stories/ReactVegaDemo.jsx
@@ -80,6 +80,8 @@ export default class Demo extends React.Component {
         <button type="button" onClick={this.handleUpdateData}>
           Update data
         </button>
+        <p>Active spec</p>
+        <pre>{spec}</pre>
         <h3>
           <code>&lt;Vega&gt;</code> React Component
         </h3>

--- a/packages/react-vega-demo/stories/ReactVegaLiteDemo.jsx
+++ b/packages/react-vega-demo/stories/ReactVegaLiteDemo.jsx
@@ -122,6 +122,8 @@ export default class Demo extends React.Component {
         <button type="button" onClick={this.handleUpdateData}>
           Update data
         </button>
+        <p>Active spec</p>
+        <pre>{spec}</pre>
         <h3>
           <code>&lt;VegaLite&gt;</code> React Component
         </h3>

--- a/packages/react-vega/README.md
+++ b/packages/react-vega/README.md
@@ -119,7 +119,52 @@ ReactDOM.render(
 );
 ```
 
-There is also a `<VegaLite>` component that behaves like `<Vega>` but always assume that the spec is `vega-lite` spec (`mode` is fixed to `vega-lite`).
+
+
+### Approach#3 Use `<VegaLite>` generic class and pass in `spec` for dynamic component.
+
+Provides a bit more flexibility, but at the cost of extra checks for spec changes.
+
+Also see packages/react-vega-demo/stories/ReactVegaLiteDemo.jsx for details
+
+#### main.js
+
+```javascript
+import React from 'react'
+import ReactDOM from 'react-dom'
+import { VegaLite } from 'react-vega'
+
+const spec = {
+  width: 400,
+  height: 200,
+  mark: 'bar',
+  encoding: {
+    x: { field: 'a', type: 'ordinal' },
+    y: { field: 'b', type: 'quantitative' },
+  },
+  data: { name: 'table' }, // note: vega-lite data attribute is a plain object instead of an array
+}
+
+const barData = {
+  table: [
+    { a: 'A', b: 28 },
+    { a: 'B', b: 55 },
+    { a: 'C', b: 43 },
+    { a: 'D', b: 91 },
+    { a: 'E', b: 81 },
+    { a: 'F', b: 53 },
+    { a: 'G', b: 19 },
+    { a: 'H', b: 87 },
+    { a: 'I', b: 52 },
+  ],
+}
+
+ReactDOM.render(
+  <VegaLite spec={spec} data={barData} />,
+  document.getElementById('bar-container')
+);
+```
+
 
 ## API
 


### PR DESCRIPTION
This adds a full listing of a VegaLite demo in the README and also adds the "active spec" being fully outputted in the storybook

It breaks slightly with the partial spec in the README to favor copy-and-pasteability and makes an explicit comment about the different in vega-lite with regards to the data attribute being a plain object

These were just random things that kind of had me confused in #74 
