### PR TITLE
fix: autosize fail sometimes(#issue78)

### DIFF
--- a/packages/react-vega/src/Vega.tsx
+++ b/packages/react-vega/src/Vega.tsx
@@ -62,6 +62,7 @@ export default class Vega extends React.PureComponent<VegaProps> {
           datasetNames.forEach(name => {
             updateData(view, name, data[name]);
           });
+          view.resize();
           view.run();
         });
       }


### PR DESCRIPTION
after updating data, the scale might change.(size of axis tick might change, etc). It is better to resize the chart to prevent part of the tick number or even legend get out of the canvas.

[Issue#78 autosize failed sometimes](https://github.com/vega/react-vega/issues/78)