### PR TITLE
feat: support top-level width and height

### DIFF
--- a/packages/react-vega-demo/stories/dimensions.stories.tsx
+++ b/packages/react-vega-demo/stories/dimensions.stories.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { storiesOf } from '@storybook/react';
+import { VegaLite } from '../../react-vega/src';
+
+const DATA = {
+  myData: [
+    { a: 'A', b: 20 },
+    { a: 'B', b: 34 },
+    { a: 'C', b: 55 },
+    { a: 'D', b: 19 },
+    { a: 'E', b: 40 },
+    { a: 'F', b: 34 },
+    { a: 'G', b: 91 },
+    { a: 'H', b: 78 },
+    { a: 'I', b: 25 },
+  ],
+};
+
+const SPEC = {
+  description: 'A simple bar chart with embedded data.',
+  layer: [
+    {
+      data: { name: 'myData' },
+      encoding: {
+        x: { field: 'a', type: 'ordinal' },
+        y: { field: 'b', type: 'quantitative' },
+      },
+      mark: 'bar',
+    },
+  ],
+};
+
+storiesOf('react-vega', module).add('width=300', () => (
+  <VegaLite spec={SPEC} data={DATA} width={300} />
+)).add('height=300', () => (
+  <VegaLite spec={SPEC} data={DATA} height={300} />
+));

--- a/packages/react-vega/src/VegaEmbed.tsx
+++ b/packages/react-vega/src/VegaEmbed.tsx
@@ -48,6 +48,8 @@ export default class VegaEmbed extends React.PureComponent<VegaEmbedProps> {
     fieldSet.delete('signalListeners');
     fieldSet.delete('spec');
     fieldSet.delete('style');
+    fieldSet.delete('width');
+    fieldSet.delete('height');
 
     // Only create a new view if necessary
     if (Array.from(fieldSet).some(f => this.props[f] !== prevProps[f])) {
@@ -129,7 +131,7 @@ export default class VegaEmbed extends React.PureComponent<VegaEmbedProps> {
   };
 
   createView() {
-    const { spec, onNewView, signalListeners = {}, ...options } = this.props;
+    const { spec, onNewView, signalListeners = {}, width, height, ...options } = this.props;
     if (this.containerRef.current) {
       const finalSpec = combineSpecWithDimension(this.props);
       this.viewPromise = vegaEmbed(this.containerRef.current, finalSpec, options)

--- a/packages/react-vega/src/VegaEmbed.tsx
+++ b/packages/react-vega/src/VegaEmbed.tsx
@@ -7,6 +7,7 @@ import { NOOP } from './constants';
 import addSignalListenersToView from './utils/addSignalListenersToView';
 import computeSpecChanges from './utils/computeSpecChanges';
 import removeSignalListenersFromView from './utils/removeSignalListenersFromView';
+import combineSpecWithDimension from './utils/combineSpecWithDimension';
 
 export type VegaEmbedProps = {
   className?: string;
@@ -16,22 +17,6 @@ export type VegaEmbedProps = {
   onNewView?: ViewListener;
   onError?: (error: Error) => void;
 } & EmbedOptions & {};
-
-export function combineSpecWithDimension(props: VegaEmbedProps): VisualizationSpec {
-  const { spec, width, height } = props;
-
-  if (typeof width !== 'undefined' && typeof height !== 'undefined') {
-    return { ...spec, width, height };
-  }
-  if (typeof width !== 'undefined') {
-    return { ...spec, width };
-  }
-  if (typeof height !== 'undefined') {
-    return { ...spec, height };
-  }
-
-  return spec;
-}
 
 export default class VegaEmbed extends React.PureComponent<VegaEmbedProps> {
   containerRef = React.createRef<HTMLDivElement>();

--- a/packages/react-vega/src/utils/combineSpecWithDimension.ts
+++ b/packages/react-vega/src/utils/combineSpecWithDimension.ts
@@ -1,0 +1,16 @@
+import { VisualizationSpec } from 'vega-embed';
+import { VegaEmbedProps } from '../VegaEmbed';
+
+export default function combineSpecWithDimension(props: VegaEmbedProps): VisualizationSpec {
+  const { spec, width, height } = props;
+  if (typeof width !== 'undefined' && typeof height !== 'undefined') {
+    return { ...spec, width, height };
+  }
+  if (typeof width !== 'undefined') {
+    return { ...spec, width };
+  }
+  if (typeof height !== 'undefined') {
+    return { ...spec, height };
+  }
+  return spec;
+}

--- a/packages/react-vega/src/utils/getUniqueFieldNames.ts
+++ b/packages/react-vega/src/utils/getUniqueFieldNames.ts
@@ -1,7 +1,4 @@
-import { VisualizationSpec } from 'vega-embed';
-import { PlainObject } from '../types';
-
-export default function getUniqueFieldNames(objects: (PlainObject | VisualizationSpec)[]) {
+export default function getUniqueFieldNames<T>(objects: T[]) {
   const fields = new Set<string>();
   objects.forEach(o => {
     Object.keys(o).forEach(field => {

--- a/packages/react-vega/test/utils/combineSpecWithDimension.test.ts
+++ b/packages/react-vega/test/utils/combineSpecWithDimension.test.ts
@@ -1,0 +1,77 @@
+import combineSpecWithDimension from '../../src/utils/combineSpecWithDimension';
+
+describe('combineSpecWithDimension(props)', () => {
+  const spec = {
+    $schema: 'https://vega.github.io/schema/vega-lite/v4.json',
+    data: {
+      values: [],
+      name: 'source',
+    },
+    mark: 'bar',
+    encoding: {
+      y: {
+        field: 'b',
+        type: 'quantitative',
+      },
+    },
+  } as const;
+
+  it('adds width and height', () => {
+    expect(combineSpecWithDimension({ spec, width: 100, height: 100 })).toEqual({
+      $schema: 'https://vega.github.io/schema/vega-lite/v4.json',
+      width: 100,
+      height: 100,
+      data: {
+        values: [],
+        name: 'source',
+      },
+      mark: 'bar',
+      encoding: {
+        y: {
+          field: 'b',
+          type: 'quantitative',
+        },
+      },
+    });
+  });
+
+  it('adds width', () => {
+    expect(combineSpecWithDimension({ spec, width: 100 })).toEqual({
+      $schema: 'https://vega.github.io/schema/vega-lite/v4.json',
+      width: 100,
+      data: {
+        values: [],
+        name: 'source',
+      },
+      mark: 'bar',
+      encoding: {
+        y: {
+          field: 'b',
+          type: 'quantitative',
+        },
+      },
+    });
+  });
+
+  it('adds height', () => {
+    expect(combineSpecWithDimension({ spec, height: 100 })).toEqual({
+      $schema: 'https://vega.github.io/schema/vega-lite/v4.json',
+      height: 100,
+      data: {
+        values: [],
+        name: 'source',
+      },
+      mark: 'bar',
+      encoding: {
+        y: {
+          field: 'b',
+          type: 'quantitative',
+        },
+      },
+    });
+  });
+
+  it('returns original if no width or height are defined', () => {
+    expect(combineSpecWithDimension({ spec })).toBe(spec);
+  });
+});


### PR DESCRIPTION
```ts
<Vega width={xxx} height={xxx} spec={xxx} />
```

The top-level `width` and `height` now should work on initialization and also will have precedent over `width` and `height` in `spec`.

Fix #79 
Replace #143 