### PR TITLE
feat: export types

### DIFF
--- a/packages/react-vega-demo/package.json
+++ b/packages/react-vega-demo/package.json
@@ -23,7 +23,12 @@
     "@storybook/addon-links": "^5.3.9",
     "@storybook/addons": "^5.3.9",
     "@storybook/react": "^5.3.9",
-    "react": "^16.12.0"
+    "@types/react": "^16.9.43",
+    "@types/react-dom": "^16.9.8",
+    "@types/react-timeout": "^1.1.1",
+    "react-timeout": "^1.2.0",
+    "react": "^16.12.0",
+    "react-dom": "^16.12.0"
   },
   "devDependencies": {
     "@babel/core": "^7.8.3",

--- a/packages/react-vega-demo/stories/ReactVegaDemo.tsx
+++ b/packages/react-vega-demo/stories/ReactVegaDemo.tsx
@@ -1,8 +1,7 @@
 /* eslint-disable no-magic-numbers */
 import React from 'react';
 import { action } from '@storybook/addon-actions';
-import { VisualizationSpec } from 'vega-embed';
-import { Vega, createClassFromSpec } from '../../react-vega/src';
+import { Vega, createClassFromSpec, VisualizationSpec } from '../../react-vega/src';
 import data1 from './vega/data1.json';
 import spec1 from './vega/spec1';
 import spec2 from './vega/spec2';

--- a/packages/react-vega-demo/stories/ReactVegaDemo.tsx
+++ b/packages/react-vega-demo/stories/ReactVegaDemo.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-magic-numbers */
 import React from 'react';
 import { action } from '@storybook/addon-actions';
+import { VisualizationSpec } from 'vega-embed';
 import { Vega, createClassFromSpec } from '../../react-vega/src';
 import data1 from './vega/data1.json';
 import spec1 from './vega/spec1';
@@ -13,7 +14,17 @@ const code1 = `<Vega data={this.state.data} spec={this.state.spec} onSignalHover
 const code2 = `const BarChart = ReactVega.createClassFromSpec(barSpec);
 <BarChart data={this.state.data} onSignalHover={this.handleHover} />`;
 
-export default class Demo extends React.Component {
+type State = {
+  data: Record<string, any>;
+  info: string;
+  spec: VisualizationSpec;
+};
+
+export default class Demo extends React.PureComponent<{}, State> {
+  handlers: {
+    tooltip: (...args: unknown[]) => void;
+  }
+
   constructor(props) {
     super(props);
     this.state = {

--- a/packages/react-vega-demo/stories/ReactVegaLiteDemo.tsx
+++ b/packages/react-vega-demo/stories/ReactVegaLiteDemo.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { VisualizationSpec } from 'vega-embed';
 import { action } from '@storybook/addon-actions';
 import { VegaLite, createClassFromSpec } from '../../react-vega/src';
 
@@ -30,7 +31,7 @@ const data2 = {
   ],
 };
 
-const spec1 = {
+const spec1: VisualizationSpec = {
   data: { name: 'myData' },
   description: 'A simple bar chart with embedded data.',
   encoding: {
@@ -40,7 +41,7 @@ const spec1 = {
   mark: 'bar',
 };
 
-const spec2 = {
+const spec2: VisualizationSpec = {
   data: { name: 'myData' },
   description: 'A simple bar chart with embedded data.',
   encoding: {
@@ -57,7 +58,17 @@ const code1 = `<VegaLite data={this.state.data} spec={this.state.spec} />`;
 const code2 = `const BarChart = ReactVegaLite.createClassFromLiteSpec(spec1);
 <BarChart data={this.state.data} />`;
 
-export default class Demo extends React.Component {
+type State = {
+  data: Record<string, any>;
+  info: string;
+  spec: VisualizationSpec;
+};
+
+export default class Demo extends React.PureComponent<{}, State> {
+  handlers: {
+    hover: (...args: unknown[]) => void;
+  }
+
   constructor(props) {
     super(props);
     this.state = {

--- a/packages/react-vega-demo/stories/ReactVegaLiteDemo.tsx
+++ b/packages/react-vega-demo/stories/ReactVegaLiteDemo.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { VisualizationSpec } from 'vega-embed';
 import { action } from '@storybook/addon-actions';
-import { VegaLite, createClassFromSpec } from '../../react-vega/src';
+import { VegaLite, createClassFromSpec, VisualizationSpec } from '../../react-vega/src';
 
 const data1 = {
   myData: [

--- a/packages/react-vega-demo/stories/vega/spec1.ts
+++ b/packages/react-vega-demo/stories/vega/spec1.ts
@@ -1,8 +1,8 @@
-import { VisualizationSpec } from 'vega-embed';
-
 // From https://vega.github.io/vega/examples/bar-chart/
 
-const spec: VisualizationSpec = {
+import { VisualizationSpec } from "../../../react-vega/src";
+
+export default {
   $schema: 'https://vega.github.io/schema/vega/v5.json',
   width: 400,
   height: 200,
@@ -91,6 +91,4 @@ const spec: VisualizationSpec = {
       },
     },
   ],
-};
-
-export default spec;
+} as VisualizationSpec;

--- a/packages/react-vega-demo/stories/vega/spec1.ts
+++ b/packages/react-vega-demo/stories/vega/spec1.ts
@@ -1,6 +1,8 @@
+import { VisualizationSpec } from 'vega-embed';
+
 // From https://vega.github.io/vega/examples/bar-chart/
 
-export default {
+const spec: VisualizationSpec = {
   $schema: 'https://vega.github.io/schema/vega/v5.json',
   width: 400,
   height: 200,
@@ -59,16 +61,16 @@ export default {
       from: { data: 'table' },
       encode: {
         enter: {
-          x: { scale: 'xscale', field: 'category', offset: 10 },
-          width: { scale: 'xscale', band: 0.5, offset: -1 },
+          x: { scale: 'xscale', field: 'category', offset: 1 },
+          width: { scale: 'xscale', band: 1, offset: -1 },
           y: { scale: 'yscale', field: 'amount' },
           y2: { scale: 'yscale', value: 0 },
         },
         update: {
-          fill: { value: 'green' },
+          fill: { value: 'steelblue' },
         },
         hover: {
-          fill: { value: 'yellow' },
+          fill: { value: 'red' },
         },
       },
     },
@@ -90,3 +92,5 @@ export default {
     },
   ],
 };
+
+export default spec;

--- a/packages/react-vega-demo/stories/vega/spec2.ts
+++ b/packages/react-vega-demo/stories/vega/spec2.ts
@@ -1,6 +1,8 @@
+import { VisualizationSpec } from 'vega-embed';
+
 // From https://vega.github.io/vega/examples/bar-chart/
 
-export default {
+const spec: VisualizationSpec = {
   $schema: 'https://vega.github.io/schema/vega/v5.json',
   width: 400,
   height: 200,
@@ -59,16 +61,16 @@ export default {
       from: { data: 'table' },
       encode: {
         enter: {
-          x: { scale: 'xscale', field: 'category', offset: 1 },
-          width: { scale: 'xscale', band: 1, offset: -1 },
+          x: { scale: 'xscale', field: 'category', offset: 10 },
+          width: { scale: 'xscale', band: 0.5, offset: -1 },
           y: { scale: 'yscale', field: 'amount' },
           y2: { scale: 'yscale', value: 0 },
         },
         update: {
-          fill: { value: 'steelblue' },
+          fill: { value: 'green' },
         },
         hover: {
-          fill: { value: 'red' },
+          fill: { value: 'yellow' },
         },
       },
     },
@@ -90,3 +92,5 @@ export default {
     },
   ],
 };
+
+export default spec;

--- a/packages/react-vega-demo/stories/vega/spec2.ts
+++ b/packages/react-vega-demo/stories/vega/spec2.ts
@@ -1,8 +1,8 @@
-import { VisualizationSpec } from 'vega-embed';
-
 // From https://vega.github.io/vega/examples/bar-chart/
 
-const spec: VisualizationSpec = {
+import { VisualizationSpec } from "../../../react-vega/src";
+
+export default {
   $schema: 'https://vega.github.io/schema/vega/v5.json',
   width: 400,
   height: 200,
@@ -91,6 +91,4 @@ const spec: VisualizationSpec = {
       },
     },
   ],
-};
-
-export default spec;
+} as VisualizationSpec;

--- a/packages/react-vega/src/createClassFromSpec.tsx
+++ b/packages/react-vega/src/createClassFromSpec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { VisualizationSpec, Mode } from 'vega-embed';
+import { VisualizationSpec, Mode } from './types';
 import Vega, { VegaProps } from './Vega';
 
 interface Constructor<T> {

--- a/packages/react-vega/src/index.ts
+++ b/packages/react-vega/src/index.ts
@@ -1,3 +1,6 @@
 export { default as Vega } from './Vega';
 export { default as VegaLite } from './VegaLite';
 export { default as createClassFromSpec } from './createClassFromSpec';
+
+// Export types
+export * from './types';

--- a/packages/react-vega/src/types/index.ts
+++ b/packages/react-vega/src/types/index.ts
@@ -1,5 +1,6 @@
 import { Result } from 'vega-embed';
 
+/** Vega View object */
 export type View = Result['view'];
 
 export type PlainObject = {
@@ -12,4 +13,7 @@ export type SignalListeners = {
   [key: string]: SignalListener;
 };
 
+/** Handler of view actions */
 export type ViewListener = (view: View) => void;
+
+export * from './reExport';

--- a/packages/react-vega/src/types/reExport.ts
+++ b/packages/react-vega/src/types/reExport.ts
@@ -1,0 +1,3 @@
+// List of types to re-export from dependencies
+
+export { VisualizationSpec, Mode } from 'vega-embed';

--- a/packages/react-vega/src/utils/combineSpecWithDimension.ts
+++ b/packages/react-vega/src/utils/combineSpecWithDimension.ts
@@ -1,4 +1,4 @@
-import { VisualizationSpec } from 'vega-embed';
+import { VisualizationSpec } from '../types';
 import { VegaEmbedProps } from '../VegaEmbed';
 
 export default function combineSpecWithDimension(props: VegaEmbedProps): VisualizationSpec {

--- a/packages/react-vega/src/utils/computeSpecChanges.ts
+++ b/packages/react-vega/src/utils/computeSpecChanges.ts
@@ -1,6 +1,6 @@
-import { VisualizationSpec } from 'vega-embed';
 import equal from 'fast-deep-equal';
 import getUniqueFieldNames from './getUniqueFieldNames';
+import { VisualizationSpec } from '../types';
 
 interface SpecChanges {
   width: false | number;
@@ -47,7 +47,7 @@ export default function computeSpecChanges(newSpec: VisualizationSpec, oldSpec: 
 
   if (
     [...fieldNames].some(
-      field =>
+      (field) =>
         !(field in newSpec) ||
         !(field in oldSpec) ||
         !equal(newSpec[field as keyof typeof newSpec], oldSpec[field as keyof typeof oldSpec]),

--- a/packages/react-vega/src/utils/getDatasetNamesFromSpec.ts
+++ b/packages/react-vega/src/utils/getDatasetNamesFromSpec.ts
@@ -1,4 +1,4 @@
-import { VisualizationSpec } from 'vega-embed';
+import { VisualizationSpec } from '../types';
 
 export default function getDatasetNamesFromSpec(spec: VisualizationSpec) {
   const { data } = spec;


### PR DESCRIPTION
Previously users had to import the type `VisualizationSpec` from `vega-embed` to correctly cast/type the `spec` objects, which can be inconvenient.

This PRs

* Re-export `VisualizationSpec` from `vega-embed` as part of `react-vega` export, so developers can

```ts
import { VisualizationSpec } from 'react-vega`;
```

* Update storybook examples to be full typescript. 