### PR TITLE
Depend explicitly on prop-types

### DIFF
--- a/packages/react-vega/package.json
+++ b/packages/react-vega/package.json
@@ -20,6 +20,7 @@
   ],
   "dependencies": {
     "@types/react": "^16.9.19",
+    "prop-types": "^15.7.2",
     "fast-deep-equal": "^3.1.1",
     "vega-embed": "^6.5.1"
   },


### PR DESCRIPTION
Fixes #441 by including prop-types in dependencies, even if react-vega doesn't use it directly.