### PR TITLE
Make @types/react more flexible

### DIFF
--- a/packages/react-vega/package.json
+++ b/packages/react-vega/package.json
@@ -19,7 +19,7 @@
     "types"
   ],
   "dependencies": {
-    "@types/react": "^16.9.19",
+    "@types/react": "^16 || ^17",
     "fast-deep-equal": "^3.1.1",
     "vega-embed": "^6.5.1"
   },


### PR DESCRIPTION
Make the dependency on @types/react similar to the one on react. This is so that users of the library (like myself) can use different versions of @types/react and still trust that it works!

Closes #435 