### PR TITLE
Add `VisualizationSpec` type to spec definition

### DIFF
--- a/packages/react-vega/README.md
+++ b/packages/react-vega/README.md
@@ -86,7 +86,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { Vega } from 'react-vega';
 
-const spec = {
+const spec: VisualizationSpec = {
   "width": 400,
   "height": 200,
   "data": [{ "name": "table" }],
@@ -134,7 +134,7 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import { VegaLite } from 'react-vega'
 
-const spec = {
+const spec: VisualizationSpec = {
   width: 400,
   height: 200,
   mark: 'bar',


### PR DESCRIPTION
Otherwise, user gets error:
```
Type '{ width: number; height: number; mark: { type: string; }; encoding: { x: { field: string; type: string; }; y: { field: string; type: string; }; }; data: { name: string; }; }' is not assignable to type 'VisualizationSpec'.
  Type '{ width: number; height: number; mark: { type: string; }; encoding: { x: { field: string; type: string; }; y: { field: string; type: string; }; }; data: { name: string; }; }' is not assignable to type 'TopLevelUnitSpec<Field>'.
    Type '{ width: number; height: number; mark: { type: string; }; encoding: { x: { field: string; type: string; }; y: { field: string; type: string; }; }; data: { name: string; }; }' is not assignable to type 'GenericUnitSpec<FacetedCompositeEncoding<Field>, AnyMark, TopLevelParameter>'.
      Types of property 'mark' are incompatible.
        Type '{ type: string; }' is not assignable to type 'AnyMark'.
          Type '{ type: string; }' is not assignable to type 'MarkDef<"bar" | "area" | "circle" | "image" | "line" | "rect" | "text" | "arc" | "point" | "rule" | "tick" | "trail" | "square" | "geoshape", ExprRef | SignalRef>'.
            Types of property 'type' are incompatible.
              Type 'string' is not assignable to type '"bar" | "area" | "circle" | "image" | "line" | "rect" | "text" | "arc" | "point" | "rule" | "tick" | "trail" | "square" | "geoshape"'.
```