### PR TITLE
docs: fix example in readme

### DIFF
--- a/packages/react-vega/README.md
+++ b/packages/react-vega/README.md
@@ -34,21 +34,23 @@ See the rest of the spec in [spec1.ts](https://github.com/vega/react-vega/blob/m
 import React, { PropTypes } from 'react';
 import { createClassFromSpec } from 'react-vega';
 
-export default createClassFromSpec('BarChart', {
-  "width": 400,
-  "height": 200,
-  "data": [{ "name": "table" }],
-  "signals": [
-    {
-      "name": "tooltip",
-      "value": {},
-      "on": [
-        {"events": "rect:mouseover", "update": "datum"},
-        {"events": "rect:mouseout",  "update": "{}"}
-      ]
-    }
-  ],
-  ... // See the rest in packages/react-vega-demo/stories/vega/spec1.ts
+export default createClassFromSpec({ mode: 'vega', spec: 
+  {
+    "width": 400,
+    "height": 200,
+    "data": [{ "name": "table" }],
+    "signals": [
+      {
+        "name": "tooltip",
+        "value": {},
+        "on": [
+          {"events": "rect:mouseover", "update": "datum"},
+          {"events": "rect:mouseout",  "update": "{}"}
+        ]
+      }
+    ],
+    ... // See the rest in packages/react-vega-demo/stories/vega/spec1.ts
+  }
 });
 ```
 


### PR DESCRIPTION
As I mentioned in this [issue](https://github.com/vega/react-vega/issues/543), your first approach is not working, but this change should fix it.